### PR TITLE
Mages logic moved to a new file

### DIFF
--- a/Berserk.toc
+++ b/Berserk.toc
@@ -10,4 +10,6 @@
 ## X-Embeds: Ace3
 
 embeds.xml
+
+Libs/classes/mages.lua
 config.lua

--- a/Libs/Classes/mages.lua
+++ b/Libs/Classes/mages.lua
@@ -1,0 +1,35 @@
+local _, BS = ...;
+
+Mages = {
+    roster = { 'Lilschierke', 'Lillybell', 'Arven', 'Firebeard', 'Merloc', 'Glico' },
+    UIOptions = {
+        header = {
+            order = 0,
+            type = "header",
+            name = "MAGES",
+        },
+        description = {
+            order = 1,
+            type = "description",
+            name = function() return Mages:Rotation() end,
+        },
+    }
+}
+
+function Mages:StringRoster()
+    return table.concat(self.roster,", ")
+end
+
+function Mages:Bench()
+    benchindex = math.fmod(52, date("%V"))
+    for i = 1, #self.roster do
+        if not i ~= benchindex then
+            bench = self.roster[i]
+        end
+    end
+    return bench
+end
+
+function Mages:Rotation()
+    return "Weekly Mage Rotation\n\n".."Roster\n    "..self:StringRoster().."\nBench:\n    "..self:Bench()
+end

--- a/Libs/Classes/mages.lua
+++ b/Libs/Classes/mages.lua
@@ -1,12 +1,16 @@
-local _, BS = ...;
-
+local _, BS = ...
+------------------------------
+-- UI definition using AceConfig-3.0 syntax
+-- https://www.wowace.com/projects/ace3/pages/ace-config-3-0-options-tables
+------------------------------
 Mages = {
     roster = { 'Lilschierke', 'Lillybell', 'Arven', 'Firebeard', 'Merloc', 'Glico' },
+    offsetRotation = 4, -- offset for our existing rotation to continue
     UIOptions = {
         header = {
             order = 0,
             type = "header",
-            name = "MAGES",
+            name = "Mages",
         },
         description = {
             order = 1,
@@ -16,20 +20,28 @@ Mages = {
     }
 }
 
-function Mages:StringRoster()
-    return table.concat(self.roster,", ")
+function Mages:BecnhIndex()
+    day = date("%a")
+    weekno = date("%V")
+    if day == "Sun" or day == "Mon" then
+        weekno = weekno - 1
+    end
+    -- +1 because lua starts arrays at 1 and not 0
+    return math.fmod(6, (52 - weekno)) + self.offsetRotation
 end
 
 function Mages:Bench()
-    benchindex = math.fmod(52, date("%V"))
-    for i = 1, #self.roster do
-        if not i ~= benchindex then
-            bench = self.roster[i]
-        end
-    end
-    return bench
+    return self.roster[self:BecnhIndex()]
 end
 
+function Mages:StringRoster()
+    return table.concat(self.roster, ", ")
+end
+
+------------------------------
+-- Rotation function is mandatory for every class
+-- Should be defined for every class in the game even if there is no bench like rogues.
+------------------------------
 function Mages:Rotation()
-    return "Weekly Mage Rotation\n\n".."Roster\n    "..self:StringRoster().."\nBench:\n    "..self:Bench()
+    return "Weekly Mage Rotation\n".."Roster\n    "..self:StringRoster().."\nBench:\n    "..self:Bench()
 end

--- a/config.lua
+++ b/config.lua
@@ -163,13 +163,12 @@ function BerserkAddon:DetectDeadPlayer()
 end
 
 function BerserkAddon:ChatCommand(input)
-
     if not input or input:trim() == "" then
         InterfaceOptionsFrame_OpenToCategory(self.optionsFrame)
     elseif input == "help" or input == "?" then
         BerserkAddon:printHelp();
     elseif input == "mr" or input == "mage rotation" then
-        BerserkAddon:prettyMageRotation();
+        BerserkAddon:printRotation(Mages)
     else
         LibStub("AceConfigCmd-3.0"):HandleCommand("bs", "BerserkAddon", input)
     end
@@ -208,7 +207,6 @@ function BerserkAddon:ToggleShowInChat_1(info, value)
     end
 end
 
-
 ------------------------------
 -- Utility Functions
 ------------------------------
@@ -221,41 +219,8 @@ function BerserkAddon:printHelp()
     );
 end
 
-------------------------------
--- Mage Specific Functions
-------------------------------
-function BerserkAddon:MageRotation()
-    m = {'Lilschierke', 'Lillybell', 'Arven', 'Firebeard', 'Merloc', 'Glico'};
-
-    day = date("%a");
-    weekno = date("%V");
-    if day == "Sun" or day == "Mon" then
-        weekno = weekno - 1;
-    end
-
-    -- +1 because lua starts arrays at 1 and not 0
-    -- +3 to offset for our existing rotation to continue
-    benchindex = math.fmod(6, (52 - weekno)) + 4;
-    roster = '';
-    for i = 1, #m do
-        if i ~= benchindex then
-            if roster == '' then
-                roster = m[i];
-            else
-                roster = roster .. ", " .. m[i];
-            end
-        else
-            bench = m[i];
-        end
-    end
-    return roster,bench;
-end
-
-function BerserkAddon:prettyMageRotation()
-    r,b = BerserkAddon:MageRotation();
-    self:Print("Weekly Mage Rotation\n",
-        "Roster\n    ",
-        r,
-        "\nBench:\n    ",
-        b);
+function BerserkAddon:printRotation(_class)
+    -- _class variable must respond to Rotation method
+    -- _class variable could be any available class in the game
+    self:Print(_class:Rotation());
 end

--- a/config.lua
+++ b/config.lua
@@ -1,3 +1,8 @@
+------------------------------
+-- variable BS is shared across the files
+------------------------------
+local _, BS = ...
+
 BerserkAddon = LibStub("AceAddon-3.0"):NewAddon("BerserkAddon", "AceConsole-3.0", "AceEvent-3.0")
 
 local defaults = {
@@ -76,13 +81,7 @@ local options = {
             order = 4,
             name = "Mages",
             type = "group",
-            args = {
-                desc = {
-                    order = 0,
-                    type = "description",
-                    name = "MSGES ARE THE BEST!",
-                },
-            }
+            args = Mages.UIOptions
         },
         priests = {
             order = 5,


### PR DESCRIPTION
- The logic behind the `bench` for mages is now divided into smallest functions/methods so that logic is easier to read
- Mages specific functions/methods moved to `Libs/Classes/Mages.lua` this is useful so we don't need to put all the logic inside the `core.lua` file
- There is a new function/method in `core.lua` called `print:Rotation(_class)` which receives a `wow class object < Mages, Rogues, etc ...` and prints its own rotation info so we don't need to create a single function for each class like:
~~_BerserkAddon:prettyMageRotation();
BerserkAddon:prettyWarriorRotation();
BerserkAddon:prettyRogueRotation();_~~
etc